### PR TITLE
Handle keys with dots by using `\\.` as the escape sequence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Fixed] Keys with dots are now properly handled; paths that contain dots will
+  now use `\\.` as a escape sequence.
+
 ## v0.2.2 - 2022-02-01
 
 - [Fixed] Properly handle numeric keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ Prefix your message with one of the following:
 
 ## Unreleased
 
-- [Fixed] Keys with dots are now properly handled; paths that contain dots will
-  now use `\\.` as a escape sequence.
+- [Fixed] Handle keys with dots properly by using `\\.` as a escape sequence.
 
 ## v0.2.2 - 2022-02-01
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,38 @@ glob.to_h
 
 Notice that the return result will have symbolized keys.
 
+If the contains dots, then the result will use `\\.` as the escape sequence.
+Similarly, you need to escape keys with dots when filtering results.
+
+```ruby
+glob = Glob.new(
+  formats: {
+    ".txt" => "Text",
+    ".json" => "JSON",
+    ".rb" => "Ruby"
+  }
+)
+
+glob << "*"
+
+glob.paths
+#=> ["formats.\\.json", "formats.\\.rb", "formats.\\.txt"]
+
+glob.to_h
+#=> {:formats=>{:".json"=>"JSON", :".rb"=>"Ruby", :".txt"=>"Text"}}
+
+# Remove all existing matchers
+glob.matchers.clear
+
+glob << "formats.\\.rb"
+
+glob.paths
+#=> ["formats.\\.rb"]
+
+glob.to_h
+#=> {:formats=>{:".rb"=>"Ruby"}}
+```
+
 ## Maintainer
 
 - [Nando Vieira](https://github.com/fnando)

--- a/lib/glob/map.rb
+++ b/lib/glob/map.rb
@@ -13,15 +13,19 @@ module Glob
 
     def call
       @target
-        .map {|(key, value)| compute(value, key) }
+        .map {|(key, value)| compute(value, escape(key)) }
         .flatten
         .sort
+    end
+
+    private def escape(key)
+      key.to_s.gsub(".", "\\.")
     end
 
     private def compute(value, path)
       if value.is_a?(Hash)
         value.map do |key, other_value|
-          compute(other_value, "#{path}.#{key}")
+          compute(other_value, "#{path}.#{escape(key)}")
         end
       else
         path.to_s

--- a/lib/glob/query.rb
+++ b/lib/glob/query.rb
@@ -18,7 +18,7 @@ module Glob
       symbolized_target = SymbolizeKeys.call(@target)
 
       paths.each_with_object({}) do |path, buffer|
-        segments = path.split(".").map(&:to_sym)
+        segments = path.split(/(?<!\\)\./).map {|key| unescape(key).to_sym }
         value = symbolized_target.dig(*segments)
         set_path_value(segments, buffer, value)
       end
@@ -39,6 +39,10 @@ module Glob
 
     private def map
       @map ||= Map.call(@target)
+    end
+
+    private def unescape(key)
+      key.to_s.gsub(/\\\./, ".")
     end
 
     private def set_path_value(segments, target, value)

--- a/test/glob_test.rb
+++ b/test/glob_test.rb
@@ -233,11 +233,9 @@ class GlobTest < Minitest::Test
 
     glob << "*"
 
-    expected = Glob::SymbolizeKeys.call(data)
-
     assert_equal %w[keys\\.with\\.dots node.more\\.keys\\.with\\.dots],
                  glob.paths
-    assert_equal expected, glob.to_h
+    assert_equal Glob::SymbolizeKeys.call(data), glob.to_h
 
     assert_equal ({node: {"more.keys.with.dots": "more dots"}}),
                  Glob.filter(data, ["node.more\\.keys\\.with\\.dots"])

--- a/test/glob_test.rb
+++ b/test/glob_test.rb
@@ -220,4 +220,26 @@ class GlobTest < Minitest::Test
 
     assert_equal expected, glob.paths
   end
+
+  test "with keys that contain dots" do
+    data = {
+      "keys.with.dots" => "dots",
+      node: {
+        "more.keys.with.dots" => "more dots"
+      }
+    }
+
+    glob = Glob.new(data)
+
+    glob << "*"
+
+    expected = Glob::SymbolizeKeys.call(data)
+
+    assert_equal %w[keys\\.with\\.dots node.more\\.keys\\.with\\.dots],
+                 glob.paths
+    assert_equal expected, glob.to_h
+
+    assert_equal ({node: {"more.keys.with.dots": "more dots"}}),
+                 Glob.filter(data, ["node.more\\.keys\\.with\\.dots"])
+  end
 end


### PR DESCRIPTION
Close #17.
