### PR TITLE
Allow setting new paths with Glob::Query#set(path, value).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Added] Allow adding new keys with `glob.set(path, value)`.
+
 ## v0.3.1 - 2022-09-01
 
 - [Fixed] Handle keys with dots properly by using `\\.` as a escape sequence.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ glob.to_h
 
 Notice that the return result will have symbolized keys.
 
-If the contains dots, then the result will use `\\.` as the escape sequence.
+If the key contain dots, then the result will use `\\.` as the escape sequence.
 Similarly, you need to escape keys with dots when filtering results.
 
 ```ruby
@@ -102,6 +102,29 @@ glob.paths
 
 glob.to_h
 #=> {:formats=>{:".rb"=>"Ruby"}}
+```
+
+You can set new keys by using `.set(path, value)`:
+
+```ruby
+glob = Glob.new
+glob << "*"
+glob.set "a.b.c", "hello"
+
+glob.to_h
+#=> {:a=>{:b=>{:c=>"hello"}}}
+
+glob.paths
+#=> ["a.b.c"]
+
+# The non-hash value will be replaced in case the new path overlaps it
+glob.set "a.b.c.d.e", "hello"
+
+glob.to_h
+#=> {:a=>{:b=>{:c=>{:d=>{:e=>"hello"}}}}}
+
+glob.paths
+#=> ["a.b.c.d.e"]
 ```
 
 ## Maintainer

--- a/lib/glob.rb
+++ b/lib/glob.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "glob/map"
-require "glob/query"
-require "glob/matcher"
-require "glob/symbolize_keys"
-require "glob/version"
+require_relative "glob/map"
+require_relative "glob/query"
+require_relative "glob/matcher"
+require_relative "glob/symbolize_keys"
+require_relative "glob/version"
 
 module Glob
   def self.filter(target, paths = ["*"])
@@ -13,7 +13,7 @@ module Glob
     glob.to_h
   end
 
-  def self.new(target)
+  def self.new(target = {})
     Query.new(target)
   end
 end

--- a/lib/glob/map.rb
+++ b/lib/glob/map.rb
@@ -7,7 +7,6 @@ module Glob
     end
 
     def initialize(target)
-      @keys = []
       @target = target
     end
 

--- a/test/glob_test.rb
+++ b/test/glob_test.rb
@@ -240,4 +240,40 @@ class GlobTest < Minitest::Test
     assert_equal ({node: {"more.keys.with.dots": "more dots"}}),
                  Glob.filter(data, ["node.more\\.keys\\.with\\.dots"])
   end
+
+  test "sorts set when setting new keys" do
+    data = {d: "d", a: "a", b: "b"}
+
+    glob = Glob.new(data)
+    glob << "*"
+
+    assert_equal({a: "a", b: "b", d: "d"}, glob.to_h)
+
+    glob.set("c", "c")
+    glob.set("e.b1.b2.b3", "e---b")
+    glob.set("e.a1.a2.a3", "e---a")
+
+    expected = {
+      a: "a", b: "b", c: "c", d: "d",
+      e: {a1: {a2: {a3: "e---a"}}, b1: {b2: {b3: "e---b"}}}
+    }
+
+    assert_equal(expected, glob.to_h)
+    assert_equal ["a", "b", "c", "d", "e.a1.a2.a3", "e.b1.b2.b3"], glob.paths
+  end
+
+  test "replaces existing node when setting a new path" do
+    glob = Glob.new(a: 1, b: {b1: {b2: 2}})
+    glob << "*"
+    glob.set("a.a1.a2", 4)
+    glob.set("b.b1.b2.b3", {b4: 5})
+
+    expected = {
+      a: {a1: {a2: 4}},
+      b: {b1: {b2: {b3: {b4: 5}}}}
+    }
+
+    assert_equal expected, glob.to_h
+    assert_equal ["a.a1.a2", "b.b1.b2.b3.b4"], glob.paths
+  end
 end


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add `Glob::Query#set(path, value)` so you can manipulate the target object.

### Why

I'm adding support for [i18n-js](https://github.com/fnando/i18n-js) plugin API and the code will benefit from this change.

### Known limitations

N/A