### PR TITLE
Fix partial matching when not using `*`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## unreleased
+
+- [Fixed] Fix partial matching when not using `*`.
+
 ## v0.4.0 - 2022-12-05
 
 - [Changed] `Glob::Query` has been renamed to `Glob::Object`.

--- a/lib/glob/matcher.rb
+++ b/lib/glob/matcher.rb
@@ -11,7 +11,8 @@ module Glob
       pattern = Regexp.escape(path.gsub(/^!/, ""))
                       .gsub(/(\\{.*?\\})/) {|match| process_group(match) }
                       .gsub("\\*", "[^.]+")
-      @regex = Regexp.new("^#{pattern}")
+      anchor = path.end_with?("*") ? "" : "$"
+      @regex = Regexp.new("^#{pattern}#{anchor}")
     end
 
     def match?(other)

--- a/test/glob_test.rb
+++ b/test/glob_test.rb
@@ -3,6 +3,17 @@
 require "test_helper"
 
 class GlobTest < Minitest::Test
+  test "with partial matching" do
+    glob = Glob.new(
+      en: {editor: "editor", edit: "edit"},
+      pt: {editor: "editor", edit: "edit"}
+    )
+
+    glob << "*.edit"
+
+    assert_equal ["en.edit", "pt.edit"], glob.paths
+  end
+
   test "with rejecting filter" do
     glob = Glob.new(
       en: {


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Fix partial matching when not using `*`.

### Why

https://github.com/fnando/i18n-js/discussions/718

### Known limitations

Unknown